### PR TITLE
Upgrade Rust Playground to use official Rust.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Currently contains the following VMs:
 - **debian-minikube-lab:** Debian Stretch 64bit which updates itself and installs latest [docker](https://www.docker.com/) and docker-compose from official repositories. Then, it adds minikube on top to form a wholly contained minikube playground. RAM is set to 6144MB (6.0GB) to make sure it can run some containers.
 - **debian-vsftpd-server:** Debian Bullseye 64bit which updates itself and installs `vsftpd` FTP daemon from official repositories. Can be used as an impromptu FTP server or just for experimentations. The server is not configured in any way. To start, add a user to the system via `adduser` and provide a password.
 - **ubuntu20.04-ssh-oidc-client:** Ubuntu 20.04LTS 64bit which updates itself and installs the [SSH-OIDC client](https://github.com/EOSC-synergy/ssh-oidc) by EOSC-Synergy. Used as a simple installation to test SSH-OIDC enabled servers around. A little more information can be found [here](http://ssh-oidc-demo.data.kit.edu/).
-- **debian-rust-playground:** Debian Bullseye 64bit which updates itself and installs `rustc`, `cargo` and `rust-doc` packages. Intended to be a lean but turnkey Rust development playground. This machine has 1024MB of RAM out of the box.
+- **debian-rust-playground:** Debian Bullseye 64bit which updates itself and installs Rust via the [script](https://www.rust-lang.org/tools/install) recommended by Rust [official website](https://www.rust-lang.org). Installation is done unattended, with default values. Intended to be a lean but turnkey Rust development playground. This machine has 1024MB of RAM out of the box.
 
 ## Private IP List
 Following list contains the Private IP addresses of the host-only networking interfaces of the machines:

--- a/debian-rust-playground/Vagrantfile
+++ b/debian-rust-playground/Vagrantfile
@@ -80,10 +80,15 @@ Vagrant.configure(2) do |config|
     DEBIAN_FRONTEND=noninteractive apt-get --yes dist-upgrade
 
     # Then install the packages that we need to work with.
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes vim screen multitail ncftp mc build-essential linux-headers-amd64 rustc cargo rust-doc
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes vim screen multitail ncftp mc build-essential linux-headers-amd64 curl
 
     # Downloading and installing things have ended, clean the downloaded packages.
     DEBIAN_FRONTEND=noninteractive apt-get clean
+
+    # Install Rust programming language as the official website suggests.
+    sudo --non-interactive --set-home --user vagrant -- /usr/bin/curl --proto '=https' --tlsv1.2 --silent --show-error --fail https://sh.rustup.rs -o rustup.sh
+    sudo --non-interactive --set-home --user vagrant -- /bin/sh rustup.sh -y
+
    SHELL
 
    config.vm.post_up_message = "Your rust playground is ready, enjoy."


### PR DESCRIPTION
Since the Rust packages coming from Debian are not the latest ones, and caused
problems during testing, a new VM using official Rust version is made.

This version works as it should for the cases I've tested.